### PR TITLE
Laravel 5.4 FatalThrowableError Exception Fix

### DIFF
--- a/src/Commands/CrawlRoutes.php
+++ b/src/Commands/CrawlRoutes.php
@@ -84,7 +84,7 @@ class CrawlRoutes extends Command
         foreach ($routeCollection as $route) {
             
             $limit = config('restricted.index_level') ?: 1;
-            $paths = explode('/', $route->getPath());
+            $paths = explode('/', $route->uri());
 
             foreach ($paths as $i => $path) {
                 if($i >= $limit)


### PR DESCRIPTION
Fixed FatalThrowableError Exception thrown in Laravel 5.4.

"Call to undefined method Illuminate\Routing\Route::getPath()"